### PR TITLE
Update homepage to list doc pages

### DIFF
--- a/src/content/docs/2025-03-06-05-56-47.md
+++ b/src/content/docs/2025-03-06-05-56-47.md
@@ -1,0 +1,19 @@
+---
+title: Homepage Update and Doc Page Issue
+description: Summary of session updating the homepage and encountering a rendering issue with doc pages.
+pubDate: 2025-03-06T05:56:47.000Z
+---
+
+# Tasks Completed
+
+1.  Updated the homepage (`src/pages/index.astro`) to dynamically display links to documentation pages.
+2.  Removed the redundant "Docs" link.
+3.  Created a pull request for these changes.
+
+# Issues Encountered
+
+1.  Encountered a rendering error ("Cannot read properties of undefined (reading 'render')") when trying to access individual documentation pages via `src/pages/docs/[...slug].astro`. The issue is likely related to how Astro is processing the content or a potential bug.
+
+# Next Steps
+
+1.  Investigate and resolve the rendering issue with the documentation pages.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,14 @@
 ---
-import Welcome from '../components/Welcome.astro';
+import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
 
-// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
-// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+const docs = await getCollection("docs");
 ---
-
 <Layout>
-	<Welcome />
+  <h1>Welcome!</h1>
+  <ul>
+    {docs.map(doc => (
+      <li><a href={`/docs/${doc.slug}`}>{doc.data.title}</a></li>
+    ))}
+  </ul>
 </Layout>


### PR DESCRIPTION
This pull request updates the homepage to include links to the documentation pages. The links to individual doc pages are generated dynamically. 

**Note:** There is currently an issue with rendering the individual doc pages. The error `Cannot read properties of undefined (reading 'render')` occurs when trying to access a doc page. This needs further investigation.