### PR TITLE
Add publication date display and sorting

### DIFF
--- a/src/content/docs/2025-03-08-11-15-28.md
+++ b/src/content/docs/2025-03-08-11-15-28.md
@@ -1,0 +1,42 @@
+---
+title: "Added Publication Date Display and Sorting"
+description: "Enhanced doc pages and index with publication dates, sorted by newest first"
+pubDate: 2025-03-08T11:15:28.000Z
+---
+
+# Context
+
+Added publication date display functionality to both individual doc pages and the main index page, with proper formatting and sorting.
+
+# Changes Made
+
+## Individual Doc Pages
+- Added publication date display between title and content
+- Formatted date using toLocaleDateString()
+- Added subtle styling for the date display
+
+## Index Page
+- Added publication dates to each doc entry
+- Implemented sorting by pubDate (newest first)
+- Enhanced layout with flexbox for title and date alignment
+- Maintained consistent date formatting and styling
+
+# Technical Details
+
+## Implementation
+- Used built-in Date formatting with toLocaleDateString()
+- Sorted docs using valueOf() comparison
+- Applied consistent styling across pages
+- Used flexbox for clean layout on index page
+
+## Dependencies
+- No new dependencies required
+- Utilized existing Astro and built-in JavaScript features
+
+# Results
+
+The changes improve the user experience by:
+- Showing when each document was published
+- Presenting newest content first
+- Maintaining consistent styling
+- Providing clear visual hierarchy

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -16,5 +16,13 @@ const { Content } = await entry.render();
 
 <DocsLayout title={`${entry.data.title} | Kevin's Work Logs`}>
         <h2>{entry.data.title}</h2>
+        <p class="pub-date">Published on: {entry.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>
         <Content />
+        <style>
+                .pub-date {
+                        color: #666;
+                        font-style: italic;
+                        margin-bottom: 2rem;
+                }
+        </style>
 </DocsLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,14 +3,20 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
 
 const docs = await getCollection("docs");
+const sortedDocs = docs.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 <DocsLayout title="Kevin's Work Logs">
   <h2>Recent Work Logs</h2>
   <ul style="list-style: none; padding: 0;">
-    {docs.map(doc => (
+    {sortedDocs.map(doc => (
       <li style="margin-bottom: 1rem;">
         <a href={`/docs/${doc.slug}`} style="color: #333; text-decoration: none; font-size: 1.1em; border-bottom: 1px solid #eee; display: block; padding: 0.5rem 0;">
-          {doc.data.title}
+          <div style="display: flex; justify-content: space-between; align-items: baseline;">
+            <span>{doc.data.title}</span>
+            <span style="color: #666; font-size: 0.9em; font-style: italic;">
+              {doc.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+            </span>
+          </div>
         </a>
       </li>
     ))}


### PR DESCRIPTION
This PR adds publication date display functionality to both individual doc pages and the main index page.

### Changes
- Added publication date display between title and content on individual doc pages
- Added publication dates to each doc entry on the index page
- Implemented sorting by pubDate (newest first)
- Enhanced layout with flexbox for clean title and date alignment
- Added session summary

### Testing
- Verified date display on individual doc pages
- Confirmed sorting works correctly on index page
- Checked consistent styling across pages