### PR TITLE
feat: add external docs support with source tracking

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,15 +1,26 @@
 import { defineCollection, z } from 'astro:content';
 
+const baseSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  // Transform string to Date object
+  pubDate: z.coerce.date(),
+  updatedDate: z.coerce.date().optional(),
+  heroImage: z.string().optional(),
+});
+
 const docsCollection = defineCollection({
-  // Type-check frontmatter using a schema
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    // Transform string to Date object
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    heroImage: z.string().optional(),
+  schema: baseSchema,
+});
+
+const externalDocsCollection = defineCollection({
+  schema: baseSchema.extend({
+    sourceRepo: z.string(),
+    importedAt: z.coerce.date(),
   }),
 });
 
-export const collections = { docs: docsCollection };
+export const collections = {
+  docs: docsCollection,
+  'external-docs': externalDocsCollection,
+};

--- a/src/content/external-docs.README.md
+++ b/src/content/external-docs.README.md
@@ -1,0 +1,39 @@
+# External Documentation
+
+This directory contains session summaries imported from other repositories through the GitHub Actions workflow.
+
+## File Structure
+
+Files in this directory follow this naming convention:
+```
+{owner}-{repo}-{original-filename}.md
+```
+
+For example: `e-jigsaw-another-repo-session-123.md`
+
+## Frontmatter Requirements
+
+Each markdown file must include the following frontmatter:
+
+```yaml
+---
+title: Session Title
+description: Brief description of the session
+pubDate: 2024-01-01 # Original publication date
+sourceRepo: owner/repository-name
+importedAt: 2024-01-02T12:34:56Z # ISO timestamp when imported
+---
+```
+
+## Workflow Process
+
+1. The GitHub Actions workflow runs every 6 hours or can be triggered manually
+2. It checks specified repositories for session summaries
+3. New summaries are copied here with added metadata
+4. A pull request is created if new content is found
+
+## Adding Source Repositories
+
+To add a new source repository:
+1. Update the `default_repos` list in the workflow script
+2. Or trigger the workflow manually with a comma-separated list of repositories

--- a/src/content/external-docs/sample-repo-test-session.md
+++ b/src/content/external-docs/sample-repo-test-session.md
@@ -1,0 +1,23 @@
+---
+title: Sample External Session
+description: This is a test session to verify external docs functionality
+pubDate: 2024-01-24
+sourceRepo: sample/test-repo
+importedAt: 2024-01-24T11:40:00Z
+---
+
+# Sample External Session
+
+This is a test session to verify that external docs are working correctly.
+
+## What we did
+
+1. Created external-docs collection
+2. Updated index page to show external docs
+3. Added metadata for source tracking
+
+## Next steps
+
+1. Create GitHub Actions workflow
+2. Test with real external repositories
+3. Add filtering and tagging features

--- a/src/pages/external-docs/[...slug].astro
+++ b/src/pages/external-docs/[...slug].astro
@@ -1,0 +1,31 @@
+---
+import { getCollection } from 'astro:content';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const docs = await getCollection('external-docs');
+  return docs.map(doc => ({
+    params: { slug: doc.slug },
+    props: { doc },
+  }));
+}
+
+const { doc } = Astro.props;
+const { Content } = await doc.render();
+---
+
+<DocsLayout title={doc.data.title}>
+  <article>
+    <div style="margin-bottom: 2rem;">
+      <h1>{doc.data.title}</h1>
+      <div style="color: #666; font-style: italic;">
+        <div>Published on {doc.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+        <div>Source: {doc.data.sourceRepo}</div>
+        <div>Imported: {new Date(doc.data.importedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+      </div>
+    </div>
+    <Content />
+  </article>
+</DocsLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,23 +2,68 @@
 import { getCollection } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
 
-const docs = await getCollection("docs");
-const sortedDocs = docs.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+// Get both local and external docs
+const [localDocs, externalDocs] = await Promise.all([
+  getCollection("docs"),
+  getCollection("external-docs"),
+]);
+
+// Combine and sort all docs by pubDate
+const allDocs = [...localDocs, ...externalDocs].sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+
+// Group docs by source
+const localDocsSection = {
+  title: "Recent Work Logs",
+  docs: localDocs.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()),
+};
+
+// Group external docs by repository
+const externalDocsGroups = externalDocs.reduce((groups, doc) => {
+  const repo = doc.data.sourceRepo;
+  if (!groups[repo]) {
+    groups[repo] = {
+      title: `Logs from ${repo}`,
+      docs: [],
+    };
+  }
+  groups[repo].docs.push(doc);
+  return groups;
+}, {});
+
+// Sort docs within each external group
+Object.values(externalDocsGroups).forEach(group => {
+  group.docs.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+});
+
+const sections = [
+  localDocsSection,
+  ...Object.values(externalDocsGroups),
+];
 ---
 <DocsLayout title="Kevin's Work Logs">
-  <h2>Recent Work Logs</h2>
-  <ul style="list-style: none; padding: 0;">
-    {sortedDocs.map(doc => (
-      <li style="margin-bottom: 1rem;">
-        <a href={`/docs/${doc.slug}`} style="color: #333; text-decoration: none; font-size: 1.1em; border-bottom: 1px solid #eee; display: block; padding: 0.5rem 0;">
-          <div style="display: flex; justify-content: space-between; align-items: baseline;">
-            <span>{doc.data.title}</span>
-            <span style="color: #666; font-size: 0.9em; font-style: italic;">
-              {doc.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
-            </span>
-          </div>
-        </a>
-      </li>
-    ))}
-  </ul>
+  {sections.map(section => (
+    <section style="margin-bottom: 2rem;">
+      <h2>{section.title}</h2>
+      <ul style="list-style: none; padding: 0;">
+        {section.docs.map(doc => (
+          <li style="margin-bottom: 1rem;">
+            <a 
+              href={`/${doc.collection}/${doc.slug}`} 
+              style="color: #333; text-decoration: none; font-size: 1.1em; border-bottom: 1px solid #eee; display: block; padding: 0.5rem 0;"
+            >
+              <div style="display: flex; justify-content: space-between; align-items: baseline;">
+                <span>{doc.data.title}</span>
+                <span style="color: #666; font-size: 0.9em; font-style: italic;">
+                  {doc.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                  {doc.data.sourceRepo && ` • ${doc.data.sourceRepo}`}
+                </span>
+              </div>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  ))}
 </DocsLayout>


### PR DESCRIPTION
This PR adds support for external documentation with source tracking and metadata.

Changes:
- Added external docs schema and configuration
- Created dynamic route for external docs
- Added sample external doc for testing
- Updated index page to show external docs
- Added source repository info display